### PR TITLE
Zamenjava termina "nema" za "vezana"

### DIFF
--- a/ucbenik/logika.tex
+++ b/ucbenik/logika.tex
@@ -118,7 +118,7 @@ eksistenčni kvantifikator & $\some{x \in X} \phi(x)$ & obstaja $x$ iz $X$ z las
 
 Oznaki $\forall$ in $\exists$ sta narobe obrnjena A in E in izhajata iz nemščine (\textbf{a}ll, \textbf{e}xistiert).
 
-Seveda je tudi kvantificirana spremenljivka nema in jo lahko poljubno preimenujemo. Izjavi $\all{x \in X} \phi(x)$ in $\all{y \in X} \phi(y)$ povesta natanko isto: vsi elementi množice $X$ imajo lastnost $\phi$.
+Seveda je tudi kvantificirana spremenljivka vezana in jo lahko poljubno preimenujemo. Izjavi $\all{x \in X} \phi(x)$ in $\all{y \in X} \phi(y)$ povesta natanko isto: vsi elementi množice $X$ imajo lastnost $\phi$.
 
 \begin{zgled}
 Vemo, da za vsako nenegativno realno število obstaja enolično določen nenegativen kvadratni koren; to izjavo lahko zapišemo na sledeči način.


### PR DESCRIPTION
Pri spremenljivkah v kvantifikatorjih je uporabljen izraz, da so neme. Ta izraz v učbeniku prej ni predstavljen, glede na kontekst mislim, da je mišljeno vezana.

Lp.